### PR TITLE
Add motocross RL demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,14 @@ Controls:
 - **Space**: rotate piece
 - **q**: quit the game
 
+
+## Motocross RL Demo
+
+This repository also includes a minimal motocross environment with a tabular Q-learning agent. The environment uses `pygame` for rendering. Install dependencies and run training with:
+
+```bash
+pip install pygame
+python3 train_agent.py
+```
+
+After training, a short demonstration will render the agent riding across the track.

--- a/motocross_env.py
+++ b/motocross_env.py
@@ -1,0 +1,58 @@
+import pygame
+import numpy as np
+import math
+
+class MotocrossEnv:
+    """Simple 1D motocross environment with optional rendering."""
+
+    def __init__(self, width=800, height=400):
+        self.width = width
+        self.height = height
+        self.track_length = 100.0
+        self.amplitude = 20.0
+        self.dt = 0.1
+        self.screen = None
+        self.reset()
+
+    def reset(self):
+        self.pos = 0.0
+        self.vel = 0.0
+        self.steps = 0
+        return self._get_state()
+
+    def _get_state(self):
+        slope = math.cos(self.pos / 3.0) * self.amplitude / 3.0
+        return np.array([self.pos, self.vel, slope], dtype=np.float32)
+
+    def step(self, action):
+        # action: -1 (brake), 0 (coast), 1 (accelerate)
+        self.vel += 0.1 * float(action)
+        # simple friction
+        self.vel *= 0.99
+        self.pos += self.vel
+        self.pos = max(0.0, min(self.track_length, self.pos))
+        self.steps += 1
+        done = self.pos >= self.track_length or self.steps >= 1000
+        reward = self.vel - 0.1 * abs(action)
+        return self._get_state(), float(reward), done
+
+    def render(self):
+        if self.screen is None:
+            pygame.init()
+            self.screen = pygame.display.set_mode((self.width, self.height))
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                self.screen = None
+                return
+        self.screen.fill((0, 0, 0))
+        points = []
+        for x in range(self.width):
+            track_x = self.track_length * x / self.width
+            y = self.height - (math.sin(track_x / 3.0) * self.amplitude + 50)
+            points.append((x, int(y)))
+        pygame.draw.lines(self.screen, (200, 200, 200), False, points, 2)
+        bike_x = int(self.pos / self.track_length * self.width)
+        bike_y = int(self.height - (math.sin(self.pos / 3.0) * self.amplitude + 50))
+        pygame.draw.circle(self.screen, (255, 0, 0), (bike_x, bike_y), 5)
+        pygame.display.flip()

--- a/q_agent.py
+++ b/q_agent.py
@@ -1,0 +1,38 @@
+import numpy as np
+import random
+
+class QAgent:
+    """Tabular Q-learning agent for the motocross environment."""
+
+    def __init__(self, pos_bins=20, vel_bins=20, actions=(-1, 0, 1), alpha=0.1, gamma=0.99, epsilon=0.1):
+        self.pos_bins = pos_bins
+        self.vel_bins = vel_bins
+        self.actions = list(actions)
+        self.alpha = alpha
+        self.gamma = gamma
+        self.epsilon = epsilon
+        self.q = np.zeros((pos_bins, vel_bins, len(self.actions)), dtype=np.float32)
+
+    def discretize(self, state):
+        pos, vel, _ = state
+        pos_bin = int(min(self.pos_bins - 1, max(0, pos / 100 * self.pos_bins)))
+        vel = max(-3.0, min(3.0, vel))
+        vel_bin = int((vel + 3.0) / 6.0 * (self.vel_bins - 1))
+        return pos_bin, vel_bin
+
+    def choose_action(self, state):
+        if random.random() < self.epsilon:
+            return random.choice(self.actions)
+        pos_bin, vel_bin = self.discretize(state)
+        idx = int(np.argmax(self.q[pos_bin, vel_bin]))
+        return self.actions[idx]
+
+    def update(self, state, action, reward, next_state, done):
+        pos_bin, vel_bin = self.discretize(state)
+        next_pos_bin, next_vel_bin = self.discretize(next_state)
+        a_idx = self.actions.index(action)
+        target = reward
+        if not done:
+            target += self.gamma * float(np.max(self.q[next_pos_bin, next_vel_bin]))
+        current = self.q[pos_bin, vel_bin, a_idx]
+        self.q[pos_bin, vel_bin, a_idx] = (1 - self.alpha) * current + self.alpha * target

--- a/train_agent.py
+++ b/train_agent.py
@@ -1,0 +1,33 @@
+import time
+from motocross_env import MotocrossEnv
+from q_agent import QAgent
+
+
+def main():
+    env = MotocrossEnv()
+    agent = QAgent()
+    episodes = 500
+    for ep in range(episodes):
+        state = env.reset()
+        done = False
+        ep_reward = 0.0
+        while not done:
+            action = agent.choose_action(state)
+            next_state, reward, done = env.step(action)
+            agent.update(state, action, reward, next_state, done)
+            state = next_state
+            ep_reward += reward
+        if ep % 100 == 0:
+            print(f"Episode {ep} reward {ep_reward:.2f}")
+    # demonstrate
+    state = env.reset()
+    done = False
+    while not done:
+        action = agent.choose_action(state)
+        state, reward, done = env.step(action)
+        env.render()
+        time.sleep(0.02)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a simple Motocross environment using pygame
- implement a tabular Q-learning agent
- provide a training script for the motocross demo
- document the demo in README

## Testing
- `pip install numpy pygame`
- `python3 train_agent.py` *(training output logged)*

------
https://chatgpt.com/codex/tasks/task_e_6884bb10c33c832b8406af29cf2ca266